### PR TITLE
Update tests related to DeleteCommand and DeleteCommandParser

### DIFF
--- a/src/main/java/seedu/address/commons/core/Messages.java
+++ b/src/main/java/seedu/address/commons/core/Messages.java
@@ -8,6 +8,7 @@ public class Messages {
     public static final String MESSAGE_UNKNOWN_COMMAND = "Unknown command";
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
     public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX = "The person index provided is invalid";
+    public static final String MESSAGE_INVALID_PERSON_INFORMATION = "No customer matching input details!";
     public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d persons listed!";
 
 }

--- a/src/main/java/seedu/address/logic/parser/ArgumentMultimap.java
+++ b/src/main/java/seedu/address/logic/parser/ArgumentMultimap.java
@@ -51,6 +51,17 @@ public class ArgumentMultimap {
     }
 
     /**
+     * Checks if the {@code prefix} only occurs once in the user input.
+     *
+     * @param prefix the prefix to check against
+     * @return true if the {@code prefix} only occurs once, otherwise false
+     */
+    public boolean isUniquePrefix(Prefix prefix) {
+        List<String> values = getAllValues(prefix);
+        return values.size() == 1;
+    }
+
+    /**
      * Returns all values of {@code prefix}.
      * If the prefix does not exist or has no values, this will return an empty list.
      * Modifying the returned list will not affect the underlying data structure of the ArgumentMultimap.

--- a/src/main/java/seedu/address/logic/parser/ArgumentMultimap.java
+++ b/src/main/java/seedu/address/logic/parser/ArgumentMultimap.java
@@ -57,7 +57,7 @@ public class ArgumentMultimap {
      * Checks if the {@code prefix} only occurs once in the user input.
      *
      * @param prefix the prefix to check against
-     * @return true if the {@code prefix} only occurs once, otherwise false
+     * @return true if the {@code prefix} only occurs once, otherwise return false
      */
     public boolean isUniquePrefix(Prefix prefix) {
         List<String> values = getAllValues(prefix);

--- a/src/main/java/seedu/address/logic/parser/ArgumentMultimap.java
+++ b/src/main/java/seedu/address/logic/parser/ArgumentMultimap.java
@@ -47,6 +47,9 @@ public class ArgumentMultimap {
      */
     public Optional<String> getValue(Prefix prefix) {
         List<String> values = getAllValues(prefix);
+        if values.size() > 1 {
+            throw new ParseException(...);  // exception details here
+        }
         return values.isEmpty() ? Optional.empty() : Optional.of(values.get(values.size() - 1));
     }
 

--- a/src/main/java/seedu/address/logic/parser/ArgumentMultimap.java
+++ b/src/main/java/seedu/address/logic/parser/ArgumentMultimap.java
@@ -47,9 +47,6 @@ public class ArgumentMultimap {
      */
     public Optional<String> getValue(Prefix prefix) {
         List<String> values = getAllValues(prefix);
-        if values.size() > 1 {
-            throw new ParseException(...);  // exception details here
-        }
         return values.isEmpty() ? Optional.empty() : Optional.of(values.get(values.size() - 1));
     }
 

--- a/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
@@ -33,10 +33,14 @@ public class DeleteCommandParser implements Parser<DeleteCommand> {
                     && !arePrefixesPresent(argMultimap, PREFIX_EMAIL);
             boolean isBothFilled = arePrefixesPresent(argMultimap, PREFIX_PHONE)
                     && arePrefixesPresent(argMultimap, PREFIX_EMAIL);
+            boolean isPrefixUnique = arePrefixesPresent(argMultimap, PREFIX_PHONE)
+                    ? argMultimap.isUniquePrefix(PREFIX_PHONE)
+                    : argMultimap.isUniquePrefix(PREFIX_EMAIL);
 
             if (isBothEmpty
                     || isBothFilled
-                    || !argMultimap.getPreamble().isEmpty()) {
+                    || !argMultimap.getPreamble().isEmpty()
+                    || !isPrefixUnique) {
                 throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
             } else if (arePrefixesPresent(argMultimap, PREFIX_PHONE)) {
                 Phone phone = ParserUtil.parsePhone(argMultimap.getValue(PREFIX_PHONE).get());
@@ -46,10 +50,8 @@ public class DeleteCommandParser implements Parser<DeleteCommand> {
                 deletePersonDescriptor.setEmail(email);
             }
 
-            if (!deletePersonDescriptor.isAnyFilled()) {
-                throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
-            }
-
+            //Checks the assumption that either the Phone_Number or Email should be filled
+            assert(deletePersonDescriptor.isAnyFilled());
             return new DeleteCommand(deletePersonDescriptor);
 
         } catch (ParseException pe) {

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -9,6 +9,7 @@ import seedu.address.model.person.Email;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
 import seedu.address.model.person.UniquePersonList;
+import seedu.address.model.person.exceptions.PersonNotFoundException;
 
 /**
  * Wraps all data at the address-book level
@@ -120,11 +121,11 @@ public class AddressBook implements ReadOnlyAddressBook {
         return persons.hashCode();
     }
 
-    public int findNum(Phone phone) {
+    public int findNum(Phone phone) throws PersonNotFoundException {
         return persons.findNum(phone);
     }
 
-    public int findEmail(Email email) {
+    public int findEmail(Email email) throws PersonNotFoundException {
         return persons.findEmail(email);
     }
 }

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -8,6 +8,7 @@ import seedu.address.commons.core.GuiSettings;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
+import seedu.address.model.person.exceptions.PersonNotFoundException;
 
 /**
  * The API of the Model component.
@@ -92,14 +93,16 @@ public interface Model {
      *
      * @param phone Phone number to search
      * @return index of the person with the same phone number
+     * @throws PersonNotFoundException if no person with corresponding phone number found
      */
-    int findNum(Phone phone);
+    int findNum(Phone phone) throws PersonNotFoundException;
 
     /**
      * Returns the index of the person with the same email.
      *
      * @param email Email to search
      * @return index of the person with the same email
+     * @throws PersonNotFoundException if no person with corresponding email found
      */
-    int findEmail(Email email);
+    int findEmail(Email email) throws PersonNotFoundException;
 }

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -14,6 +14,7 @@ import seedu.address.commons.core.LogsCenter;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
+import seedu.address.model.person.exceptions.PersonNotFoundException;
 
 /**
  * Represents the in-memory model of the address book data.
@@ -114,13 +115,13 @@ public class ModelManager implements Model {
     }
 
     @Override
-    public int findNum(Phone phone) {
+    public int findNum(Phone phone) throws PersonNotFoundException {
         requireNonNull(phone);
         return addressBook.findNum(phone);
     }
 
     @Override
-    public int findEmail(Email email) {
+    public int findEmail(Email email) throws PersonNotFoundException {
         requireNonNull(email);
         return addressBook.findEmail(email);
     }

--- a/src/main/java/seedu/address/model/person/UniquePersonList.java
+++ b/src/main/java/seedu/address/model/person/UniquePersonList.java
@@ -38,25 +38,35 @@ public class UniquePersonList implements Iterable<Person> {
     }
 
     /**
-     * Returns the index of the Person with the same phone number.
+     * Returns the index of the Customer with the same phone number.
      *
      * @param toCheck Phone number to check against the list
-     * @return index of the Person with the same phone number in the list.
+     * @return index of the Person with the same phone number in the list
+     * @throws PersonNotFoundException if no Customer with corresponding phone number found
      */
-    public int findNum(Phone toCheck) {
+    public int findNum(Phone toCheck) throws PersonNotFoundException {
         requireNonNull(toCheck);
-        return internalList.stream().map(Person::getPhone).collect(Collectors.toList()).indexOf(toCheck);
+        int index = internalList.stream().map(Person::getPhone).collect(Collectors.toList()).indexOf(toCheck);
+        if (index == -1) {
+            throw new PersonNotFoundException();
+        }
+        return index;
     }
 
     /**
-     * Returns the index of the Person with the same email.
+     * Returns the index of the Customer with the same email.
      *
      * @param toCheck Email to check against the list
      * @return index of the Person with the same email in the list
+     * @throws PersonNotFoundException if no Customer with corresponding email found
      */
-    public int findEmail(Email toCheck) {
+    public int findEmail(Email toCheck) throws PersonNotFoundException {
         requireNonNull(toCheck);
-        return internalList.stream().map(Person::getEmail).collect(Collectors.toList()).indexOf(toCheck);
+        int index = internalList.stream().map(Person::getEmail).collect(Collectors.toList()).indexOf(toCheck);
+        if (index == -1) {
+            throw new PersonNotFoundException();
+        }
+        return index;
     }
 
     /**

--- a/src/test/java/seedu/address/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/address/logic/LogicManagerTest.java
@@ -1,7 +1,7 @@
 package seedu.address.logic;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-//import static seedu.address.commons.core.Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX;
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_PERSON_INFORMATION;
 import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
 import static seedu.address.logic.commands.CommandTestUtil.ADDRESS_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.EMAIL_DESC_AMY;
@@ -56,13 +56,13 @@ public class LogicManagerTest {
         assertParseException(invalidCommand, MESSAGE_UNKNOWN_COMMAND);
     }
 
-    /*
+
     @Test
     public void execute_commandExecutionError_throwsCommandException() {
-        String deleteCommand = "delete 9";
-        assertCommandException(deleteCommand, MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        String deleteCommand = "delete p/00000000"; // No Customer with this number exist
+        assertCommandException(deleteCommand, MESSAGE_INVALID_PERSON_INFORMATION);
     }
-    */
+
 
     @Test
     public void execute_validCommand_success() throws Exception {

--- a/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
@@ -1,23 +1,22 @@
 package seedu.address.logic.commands;
 
-//import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-//import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
-//import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
-//import static seedu.address.logic.commands.CommandTestUtil.showPersonAtIndex;
-//import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
-//import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
-/*
+
 import org.junit.jupiter.api.Test;
 
 import seedu.address.commons.core.Messages;
 import seedu.address.commons.core.index.Index;
- */
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
-//import seedu.address.model.person.Person;
+import seedu.address.model.person.Email;
+import seedu.address.model.person.Person;
+import seedu.address.model.person.Phone;
+
 
 /**
  * Contains integration tests (interaction with the Model) and unit tests for
@@ -27,11 +26,19 @@ public class DeleteCommandTest {
 
     private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
 
-    /*
     @Test
-    public void execute_validIndexUnfilteredList_success() {
-        Person personToDelete = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
-        DeleteCommand deleteCommand = new DeleteCommand(INDEX_FIRST_PERSON);
+    public void execute_validPhoneArg_success() {
+        // Corresponds to phone number input for "ALICE" under TypicalPersons class
+        DeleteCommand.DeletePersonDescriptor deletePersonDescriptor = new DeleteCommand.DeletePersonDescriptor();
+        deletePersonDescriptor.setPhone(new Phone("94351253"));
+
+        // Gets the index of Customer (ALICE) within the list via her phone number
+        int index = model.findNum(deletePersonDescriptor.getPhone());
+        Index targetIndex = Index.fromZeroBased(index);
+
+        // Gets ALICE
+        Person personToDelete = model.getFilteredPersonList().get(targetIndex.getZeroBased());
+        DeleteCommand deleteCommand = new DeleteCommand(deletePersonDescriptor);
 
         String expectedMessage = String.format(DeleteCommand.MESSAGE_DELETE_PERSON_SUCCESS, personToDelete);
 
@@ -42,71 +49,105 @@ public class DeleteCommandTest {
     }
 
     @Test
-    public void execute_invalidIndexUnfilteredList_throwsCommandException() {
-        Index outOfBoundIndex = Index.fromOneBased(model.getFilteredPersonList().size() + 1);
-        DeleteCommand deleteCommand = new DeleteCommand(outOfBoundIndex);
+    public void execute_invalidPhoneArg_throwsCommandException() {
+        // Corresponds to a random phone number input not in the TypicalPersons class
+        DeleteCommand.DeletePersonDescriptor deletePersonDescriptor = new DeleteCommand.DeletePersonDescriptor();
+        deletePersonDescriptor.setPhone(new Phone("11111111"));
 
-        assertCommandFailure(deleteCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        // Throws a CommandException due to no corresponding Customer found
+        DeleteCommand deleteCommand = new DeleteCommand(deletePersonDescriptor);
+
+        assertCommandFailure(deleteCommand, model, Messages.MESSAGE_INVALID_PERSON_INFORMATION);
     }
 
     @Test
-    public void execute_validIndexFilteredList_success() {
-        showPersonAtIndex(model, INDEX_FIRST_PERSON);
+    public void execute_validEmailArg_success() {
+        // Corresponds to email input for "CARL" under TypicalPersons class
+        DeleteCommand.DeletePersonDescriptor deletePersonDescriptor = new DeleteCommand.DeletePersonDescriptor();
+        deletePersonDescriptor.setEmail(new Email("heinz@example.com"));
 
-        Person personToDelete = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
-        DeleteCommand deleteCommand = new DeleteCommand(INDEX_FIRST_PERSON);
+        // Gets the index of Customer (CARL) within the list via his email
+        int index = model.findEmail(deletePersonDescriptor.getEmail());
+        Index targetIndex = Index.fromZeroBased(index);
+
+        // Gets CARL
+        Person personToDelete = model.getFilteredPersonList().get(targetIndex.getZeroBased());
+        DeleteCommand deleteCommand = new DeleteCommand(deletePersonDescriptor);
 
         String expectedMessage = String.format(DeleteCommand.MESSAGE_DELETE_PERSON_SUCCESS, personToDelete);
 
-        Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+        ModelManager expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
         expectedModel.deletePerson(personToDelete);
-        showNoPerson(expectedModel);
 
         assertCommandSuccess(deleteCommand, model, expectedMessage, expectedModel);
     }
 
     @Test
-    public void execute_invalidIndexFilteredList_throwsCommandException() {
-        showPersonAtIndex(model, INDEX_FIRST_PERSON);
+    public void execute_invalidEmailArg_throwsCommandException() {
+        // Corresponds to a random email input not in the TypicalPersons class
+        DeleteCommand.DeletePersonDescriptor deletePersonDescriptor = new DeleteCommand.DeletePersonDescriptor();
+        deletePersonDescriptor.setEmail(new Email("testing123@test.com"));
 
-        Index outOfBoundIndex = INDEX_SECOND_PERSON;
-        // ensures that outOfBoundIndex is still in bounds of address book list
-        assertTrue(outOfBoundIndex.getZeroBased() < model.getAddressBook().getPersonList().size());
+        // Throws a CommandException due to no corresponding Customer found
+        DeleteCommand deleteCommand = new DeleteCommand(deletePersonDescriptor);
 
-        DeleteCommand deleteCommand = new DeleteCommand(outOfBoundIndex);
-
-        assertCommandFailure(deleteCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        assertCommandFailure(deleteCommand, model, Messages.MESSAGE_INVALID_PERSON_INFORMATION);
     }
 
     @Test
     public void equals() {
-        DeleteCommand deleteFirstCommand = new DeleteCommand(INDEX_FIRST_PERSON);
-        DeleteCommand deleteSecondCommand = new DeleteCommand(INDEX_SECOND_PERSON);
+        // (Phone Number) input values for deleteFirstCommand
+        DeleteCommand.DeletePersonDescriptor deletePersonDescriptor = new DeleteCommand.DeletePersonDescriptor();
+        deletePersonDescriptor.setPhone(new Phone("12345678"));
 
-        // same object -> returns true
+        // (Phone Number) input values for deleteSecondCommand
+        DeleteCommand.DeletePersonDescriptor deletePersonDescriptor2 = new DeleteCommand.DeletePersonDescriptor();
+        deletePersonDescriptor2.setPhone(new Phone("87654321"));
+
+        // (Email) input values for deleteThirdCommand
+        DeleteCommand.DeletePersonDescriptor deletePersonDescriptor3 = new DeleteCommand.DeletePersonDescriptor();
+        deletePersonDescriptor3.setEmail(new Email("test@test.com"));
+
+        // (Email) input values for deleteFourthCommand
+        DeleteCommand.DeletePersonDescriptor deletePersonDescriptor4 = new DeleteCommand.DeletePersonDescriptor();
+        deletePersonDescriptor4.setEmail(new Email("test2@test2.com"));
+
+        DeleteCommand deleteFirstCommand = new DeleteCommand(deletePersonDescriptor);
+        DeleteCommand deleteSecondCommand = new DeleteCommand(deletePersonDescriptor2);
+
+        DeleteCommand deleteThirdCommand = new DeleteCommand(deletePersonDescriptor3);
+        DeleteCommand deleteFourthCommand = new DeleteCommand(deletePersonDescriptor4);
+
+        // (Phone Number) same object -> returns true
         assertTrue(deleteFirstCommand.equals(deleteFirstCommand));
 
-        // same values -> returns true
-        DeleteCommand deleteFirstCommandCopy = new DeleteCommand(INDEX_FIRST_PERSON);
+        // (Phone Number) same values -> returns true
+        DeleteCommand deleteFirstCommandCopy = new DeleteCommand(deletePersonDescriptor);
         assertTrue(deleteFirstCommand.equals(deleteFirstCommandCopy));
 
-        // different types -> returns false
+        // (Phone Number) different types -> returns false
         assertFalse(deleteFirstCommand.equals(1));
 
-        // null -> returns false
+        // (Phone Number) null -> returns false
         assertFalse(deleteFirstCommand.equals(null));
 
-        // different person -> returns false
+        // (Phone Number) different customer -> returns false
         assertFalse(deleteFirstCommand.equals(deleteSecondCommand));
-    }
-     */
 
-    /**
-     * Updates {@code model}'s filtered list to show no one.
-     */
-    private void showNoPerson(Model model) {
-        model.updateFilteredPersonList(p -> false);
+        // (Email) same object -> returns true
+        assertTrue(deleteThirdCommand.equals(deleteThirdCommand));
 
-        assertTrue(model.getFilteredPersonList().isEmpty());
+        // (Email) same values -> returns true
+        DeleteCommand deleteThirdCommandCopy = new DeleteCommand(deletePersonDescriptor3);
+        assertTrue(deleteThirdCommand.equals(deleteThirdCommandCopy));
+
+        // (Email) different types -> returns false
+        assertFalse(deleteThirdCommand.equals(1));
+
+        // (Email) null -> returns false
+        assertFalse(deleteThirdCommand.equals(null));
+
+        // (Email) different customer -> returns false
+        assertFalse(deleteThirdCommand.equals(deleteFourthCommand));
     }
 }

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -15,7 +15,7 @@ import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.commands.ClearCommand;
-//import seedu.address.logic.commands.DeleteCommand;
+import seedu.address.logic.commands.DeleteCommand;
 //import seedu.address.logic.commands.EditCommand;
 //import seedu.address.logic.commands.EditCommand.EditPersonDescriptor;
 import seedu.address.logic.commands.ExitCommand;
@@ -24,7 +24,9 @@ import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.AllInfoContainsKeywordsPredicate;
+import seedu.address.model.person.Email;
 import seedu.address.model.person.Person;
+import seedu.address.model.person.Phone;
 //import seedu.address.testutil.EditPersonDescriptorBuilder;
 import seedu.address.testutil.PersonBuilder;
 import seedu.address.testutil.PersonUtil;
@@ -46,21 +48,32 @@ public class AddressBookParserTest {
         assertTrue(parser.parseCommand(ClearCommand.COMMAND_WORD + " 3") instanceof ClearCommand);
     }
 
-    //@Test
-    //public void parseCommand_delete() throws Exception {
-    //    DeleteCommand command = (DeleteCommand) parser.parseCommand(
-    //            DeleteCommand.COMMAND_WORD + " " + INDEX_FIRST_PERSON.getOneBased());
-    //    assertEquals(new DeleteCommand(INDEX_FIRST_PERSON), command);
-    //}
+    @Test
+    public void parseCommand_delete() throws Exception {
+        DeleteCommand.DeletePersonDescriptor deletePersonDescriptor = new DeleteCommand.DeletePersonDescriptor();
+        deletePersonDescriptor.setPhone(new Phone("12345678"));
+        DeleteCommand command = (DeleteCommand) parser.parseCommand(
+                DeleteCommand.COMMAND_WORD + " p/12345678");
 
-    //    @Test
-    //    public void parseCommand_edit() throws Exception {
-    //        Person person = new PersonBuilder().build();
-    //        EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder(person).build();
-    //        EditCommand command = (EditCommand) parser.parseCommand(EditCommand.COMMAND_WORD + " "
-    //                + INDEX_FIRST_PERSON.getOneBased() + " " + PersonUtil.getEditPersonDescriptorDetails(descriptor));
-    //        assertEquals(new EditCommand(INDEX_FIRST_PERSON, descriptor), command);
-    //          }
+        DeleteCommand.DeletePersonDescriptor deletePersonDescriptor2 = new DeleteCommand.DeletePersonDescriptor();
+        deletePersonDescriptor2.setEmail(new Email("testing@test.com"));
+        DeleteCommand command2 = (DeleteCommand) parser.parseCommand(
+                DeleteCommand.COMMAND_WORD + " e/testing@test.com");
+
+        assertEquals(new DeleteCommand(deletePersonDescriptor), command);
+        assertEquals(new DeleteCommand(deletePersonDescriptor2), command2);
+    }
+
+    /*
+    @Test
+    public void parseCommand_edit() throws Exception {
+        Person person = new PersonBuilder().build();
+        EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder(person).build();
+        EditCommand command = (EditCommand) parser.parseCommand(EditCommand.COMMAND_WORD + " "
+                + INDEX_FIRST_PERSON.getOneBased() + " " + PersonUtil.getEditPersonDescriptorDetails(descriptor));
+        assertEquals(new EditCommand(INDEX_FIRST_PERSON, descriptor), command);
+    }
+    */
 
     @Test
     public void parseCommand_exit() throws Exception {
@@ -91,7 +104,7 @@ public class AddressBookParserTest {
     @Test
     public void parseCommand_unrecognisedInput_throwsParseException() {
         assertThrows(ParseException.class, String.format(MESSAGE_INVALID_COMMAND_FORMAT, HelpCommand.MESSAGE_USAGE), ()
-            -> parser.parseCommand(""));
+                -> parser.parseCommand(""));
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
@@ -2,12 +2,13 @@ package seedu.address.logic.parser;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
-//import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
-//import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 
 import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.DeleteCommand;
+import seedu.address.model.person.Email;
+import seedu.address.model.person.Phone;
 
 /**
  * As we are only doing white-box testing, our test cases do not cover path variations
@@ -20,13 +21,59 @@ public class DeleteCommandParserTest {
 
     private DeleteCommandParser parser = new DeleteCommandParser();
 
-    //@Test
-    //public void parse_validArgs_returnsDeleteCommand() {
-    //    assertParseSuccess(parser, "1", new DeleteCommand(INDEX_FIRST_PERSON));
-    //}
+    @Test
+    public void parse_validPhoneArg_returnsDeleteCommand() {
+        DeleteCommand.DeletePersonDescriptor deletePersonDescriptor = new DeleteCommand.DeletePersonDescriptor();
+        deletePersonDescriptor.setPhone(new Phone("12345678"));
+        assertParseSuccess(parser, " p/12345678", new DeleteCommand(deletePersonDescriptor));
+    }
 
     @Test
-    public void parse_invalidArgs_throwsParseException() {
-        assertParseFailure(parser, "a", String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
+    public void parse_validEmailArg_returnsDeleteCommand() {
+        DeleteCommand.DeletePersonDescriptor deletePersonDescriptor = new DeleteCommand.DeletePersonDescriptor();
+        deletePersonDescriptor.setEmail(new Email("test@test.com"));
+        assertParseSuccess(parser, " e/test@test.com", new DeleteCommand(deletePersonDescriptor));
+    }
+
+    @Test
+    public void parse_emptyArg_throwsParseException() {
+        assertParseFailure(parser, "",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_emptyPhoneArg_throwsParseException() {
+        assertParseFailure(parser, " p/",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_emptyEmailArg_throwsParseException() {
+        assertParseFailure(parser, " e/",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_invalidArg_throwsParseException() {
+        assertParseFailure(parser, "testing123",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_bothArgs_throwsParseException() {
+        assertParseFailure(parser, " p/12345678 e/test@test.com",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_multiplePhoneArgs_throwsParseException() {
+        assertParseFailure(parser, " p/12345678 p/87654321",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_multipleEmailArgs_throwsParseException() {
+        assertParseFailure(parser, " e/test@test.com e/test123@test.com",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
     }
 }


### PR DESCRIPTION
The existing test cases for DeleteCommand and DeleteCommandParser are testing based on deleting via index.

We adopted a new implementation of DeleteCommand to delete via phone number or email input, hence we have to edit the test cases according to the new implementation.

Let's remove the test cases related to testing via index and create new test cases based on phone number and email inputs.

Some tests for valid inputs include:
* Valid phone number/email specified ("delete p/12345678") or ("delete e/test@test.com")

Some tests for invalid inputs include:
* Multiple same prefixes ("delete p/12345678 p/87654321") or ("delete e/test@gmail.com e/test1@gmail.com") will not work since there are multiple prefixes specified
* Validity of phone number/email input, whether there are customers with corresponding email/phone number
* Multiple different prefixes ("delete p/12345678 e/test@gmail.com") will not work since there are both phone number and email specified
* Empty inputs and prefixes such as ("delete"), ("delete p/"), ("delete e/") will not work
* Invalid formats like ("delete hello123") without prefix

This helps to cover some of the potential invalid inputs from users.

There are also changes made to some of these methods:
* DeleteCommand's equals method
* DeletePersonDescriptor's equals method
* findNum method
* findEmail method