### PR TITLE
Update AddCommand to only accept unique Prefixes

### DIFF
--- a/src/main/java/seedu/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommandParser.java
@@ -33,8 +33,14 @@ public class AddCommandParser implements Parser<AddCommand> {
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_REWARD, PREFIX_TAG);
 
+        boolean isUniquePrefix = argMultimap.isUniquePrefix(PREFIX_NAME)
+                                    && argMultimap.isUniquePrefix(PREFIX_PHONE)
+                                    && argMultimap.isUniquePrefix(PREFIX_EMAIL)
+                                    && argMultimap.isUniquePrefix(PREFIX_REWARD);
+
         if (!arePrefixesPresent(argMultimap, PREFIX_NAME, PREFIX_REWARD, PREFIX_PHONE, PREFIX_EMAIL)
-                || !argMultimap.getPreamble().isEmpty()) {
+                || !argMultimap.getPreamble().isEmpty()
+                || !isUniquePrefix) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
         }
 

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -56,7 +56,7 @@ public class AddCommandTest {
     @Test
     public void equals() {
         Person alice = new PersonBuilder().withName("Alice").build();
-        Person bob = new PersonBuilder().withName("Bob").build();
+        Person bob = new PersonBuilder().withName("Bob").withPhone("83838000").build();
         AddCommand addAliceCommand = new AddCommand(alice);
         AddCommand addBobCommand = new AddCommand(bob);
 
@@ -73,8 +73,13 @@ public class AddCommandTest {
         // null -> returns false
         assertFalse(addAliceCommand.equals(null));
 
-        // different person -> returns false
-        // assertFalse(addAliceCommand.equals(addBobCommand));
+        // different name, same email, different phone -> returns true
+        assertTrue(addAliceCommand.equals(addBobCommand));
+
+        // different name, same phone, different email -> returns true
+        bob = new PersonBuilder().withName("Bob").withEmail("bob@example.com").build();
+        addBobCommand = new AddCommand(bob);
+        assertTrue(addAliceCommand.equals(addBobCommand));
     }
 
     /**

--- a/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
@@ -51,27 +51,32 @@ public class AddCommandParserTest {
         assertParseSuccess(parser, PREAMBLE_WHITESPACE + NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB
             + REWARD_DESC_BOB + TAG_DESC_MEMBER, new AddCommand(expectedPerson));
 
-        // multiple names - last name accepted
-        assertParseSuccess(parser, NAME_DESC_AMY + NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB
-            + REWARD_DESC_BOB + TAG_DESC_MEMBER, new AddCommand(expectedPerson));
-
-        // multiple phones - last phone accepted
-        assertParseSuccess(parser, NAME_DESC_BOB + PHONE_DESC_AMY + PHONE_DESC_BOB + EMAIL_DESC_BOB
-            + REWARD_DESC_BOB + TAG_DESC_MEMBER, new AddCommand(expectedPerson));
-
-        // multiple emails - last email accepted
-        assertParseSuccess(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_AMY + EMAIL_DESC_BOB
-            + REWARD_DESC_BOB + TAG_DESC_MEMBER, new AddCommand(expectedPerson));
-
-        // multiple addresses - last address accepted
-        assertParseSuccess(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + REWARD_DESC_AMY
-            + REWARD_DESC_BOB + TAG_DESC_MEMBER, new AddCommand(expectedPerson));
-
         // multiple tags - all accepted
         Person expectedPersonMultipleTags = new PersonBuilder(BOB).withTags(VALID_TAG_MEMBER, VALID_TAG_GOLD)
             .build();
         assertParseSuccess(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + REWARD_DESC_BOB
             + TAG_DESC_GOLD + TAG_DESC_MEMBER, new AddCommand(expectedPersonMultipleTags));
+    }
+
+    @Test
+    public void parse_multipleUniqueFields_failure() {
+        String message = String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE);
+
+        // multiple names - rejected
+        assertParseFailure(parser, NAME_DESC_AMY + NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB
+            + REWARD_DESC_BOB + TAG_DESC_MEMBER, message);
+
+        // multiple phones - rejected
+        assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_AMY + PHONE_DESC_BOB + EMAIL_DESC_BOB
+            + REWARD_DESC_BOB + TAG_DESC_MEMBER, message);
+
+        // multiple emails - rejected
+        assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_AMY + EMAIL_DESC_BOB
+            + REWARD_DESC_BOB + TAG_DESC_MEMBER, message);
+
+        // multiple rewards - rejected
+        assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + REWARD_DESC_AMY
+            + REWARD_DESC_BOB + TAG_DESC_MEMBER, message);
     }
 
     @Test


### PR DESCRIPTION
AddCommand allows multiple prefixes for unique fields. (e.g. "`add n/name1 n/name2 ...`" will add a new Customer with name of "`name2`"). `name1` will not be read.

Allowing multiple entries for unique fields causes unintended outcomes.

Checking whether unique fields have unique entries will prevent unintended outcomes, such as `name1` not being read in the example above.

Let's perform this check in AddCommandParser.java since this class is responsible for dealing with user input.