### PR TITLE
Abstract error messages for DeleteCommandParser

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -251,7 +251,7 @@ The following activity diagram summarizes the flow of when a user enters an edit
 
 ### \[Insert Numbering\] Delete feature
 The Delete feature is facilitated by `LogicManager`. The `DeleteCommandParser` parses the command arguments, and returns
-an `DeleteCommand` that is executed by the `LogicManager` and returns a `CommandResult` as feedback to the user.
+a `DeleteCommand` that is executed by the `LogicManager` and returns a `CommandResult` as feedback to the user.
 
 This feature enables the user to remove a customer from bobaBot via either the `PHONE` or `EMAIL` identifier.
 

--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -250,8 +250,19 @@ The following activity diagram summarizes the flow of when a user enters an edit
 
 
 ### \[Insert Numbering\] Delete feature
+The Delete feature is facilitated by `LogicManager`. The `DeleteCommandParser` parses the command arguments, and returns
+an `DeleteCommand` that is executed by the `LogicManager` and returns a `CommandResult` as feedback to the user.
 
-The delete feature enables the user to remove a customer from bobaBot. The user's input is first retrieved by the `MainWindow` class. It is then passed to the `LogicManager` through the `execute` method. `LogicManager` will call the `parseCommand` method of `AddressBookParser` which upon parsing the input, creates a temporary `DeleteCommandParser` object. The `DeleteCommandParser` object then further parses the user's input and returns a `DeleteCommand`.  The command is executed in the `LogicManager`, returning a `CommandResult` object which will then be returned as feedback to the user.
+This feature enables the user to remove a customer from bobaBot via either the `PHONE` or `EMAIL` identifier.
+
+**Below is a sample usage and how the delete sequence behaves at each step.**
+
+1. User chooses the Customer he/she wants to delete and enters the command `delete p/12345678`
+2. The `MainWindow` class retrieves the user's input and passes it on to the `LogicManager` through the `execute` method
+3. The `LogicManager` redirects this command to `AddressBookParser` via the `parseCommand` method and creates a temporary `DeleteCommandParser` object 
+4. The `DeleteCommandParser` object parses the command and returns the `DeleteCommand` containing the details of the Customer to delete
+5. The `LogicManager` executes the `DeleteCommand`, removing the Customer from bobaBot and returning a `CommandResult` object
+6. The `CommandResult` reflects the removal of this Customer
 
 The sequence diagram below shows how the `delete` feature parsing an input `p/12345678` behaves at each step.
 

--- a/src/main/java/seedu/address/commons/core/Messages.java
+++ b/src/main/java/seedu/address/commons/core/Messages.java
@@ -7,6 +7,11 @@ public class Messages {
 
     public static final String MESSAGE_UNKNOWN_COMMAND = "Unknown command";
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
+    public static final String MESSAGE_NO_UNIQUE_PREFIX_IDENTIFIER =
+            "Please use ONLY ONE phone or email as identifier \n%1$s";
+    public static final String MESSAGE_BOTH_EMAIL_AND_PHONE =
+            "Please use only EMAIL or PHONE as identifier, NOT BOTH! \n%1$s";
+    public static final String MESSAGE_EMPTY_EMAIL_AND_PHONE = "No EMAIL or PHONE identifier found in command! \n%1$s";
     public static final String MESSAGE_INVALID_PERSON_INFORMATION = "No customer matching input details!";
     public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d persons listed!";
 

--- a/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
@@ -1,6 +1,9 @@
 package seedu.address.logic.parser;
 
+import static seedu.address.commons.core.Messages.MESSAGE_BOTH_EMAIL_AND_PHONE;
+import static seedu.address.commons.core.Messages.MESSAGE_EMPTY_EMAIL_AND_PHONE;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.commons.core.Messages.MESSAGE_NO_UNIQUE_PREFIX_IDENTIFIER;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 
@@ -37,11 +40,15 @@ public class DeleteCommandParser implements Parser<DeleteCommand> {
                     ? argMultimap.isUniquePrefix(PREFIX_PHONE)
                     : argMultimap.isUniquePrefix(PREFIX_EMAIL);
 
-            if (isBothEmpty
-                    || isBothFilled
-                    || !argMultimap.getPreamble().isEmpty()
-                    || !isPrefixUnique) {
+            if (isBothEmpty) {
+                throw new ParseException(String.format(MESSAGE_EMPTY_EMAIL_AND_PHONE, DeleteCommand.MESSAGE_USAGE));
+            } else if (isBothFilled) {
+                throw new ParseException(String.format(MESSAGE_BOTH_EMAIL_AND_PHONE, DeleteCommand.MESSAGE_USAGE));
+            } else if (!argMultimap.getPreamble().isEmpty()) {
                 throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
+            } else if (!isPrefixUnique) {
+                throw new ParseException(String.format(MESSAGE_NO_UNIQUE_PREFIX_IDENTIFIER,
+                        DeleteCommand.MESSAGE_USAGE));
             } else if (arePrefixesPresent(argMultimap, PREFIX_PHONE)) {
                 Phone phone = ParserUtil.parsePhone(argMultimap.getValue(PREFIX_PHONE).get());
                 deletePersonDescriptor.setPhone(phone);
@@ -55,8 +62,7 @@ public class DeleteCommandParser implements Parser<DeleteCommand> {
             return new DeleteCommand(deletePersonDescriptor);
 
         } catch (ParseException pe) {
-            throw new ParseException(
-                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE), pe);
+            throw new ParseException(pe.getMessage(), pe);
         }
     }
 

--- a/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
@@ -1,6 +1,9 @@
 package seedu.address.logic.parser;
 
+import static seedu.address.commons.core.Messages.MESSAGE_BOTH_EMAIL_AND_PHONE;
+import static seedu.address.commons.core.Messages.MESSAGE_EMPTY_EMAIL_AND_PHONE;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.commons.core.Messages.MESSAGE_NO_UNIQUE_PREFIX_IDENTIFIER;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 
@@ -38,42 +41,54 @@ public class DeleteCommandParserTest {
     @Test
     public void parse_emptyArg_throwsParseException() {
         assertParseFailure(parser, "",
-                String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
+                String.format(MESSAGE_EMPTY_EMAIL_AND_PHONE, DeleteCommand.MESSAGE_USAGE));
     }
 
     @Test
     public void parse_emptyPhoneArg_throwsParseException() {
         assertParseFailure(parser, " p/",
-                String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
+                String.format(Phone.MESSAGE_CONSTRAINTS, DeleteCommand.MESSAGE_USAGE));
     }
 
     @Test
     public void parse_emptyEmailArg_throwsParseException() {
         assertParseFailure(parser, " e/",
-                String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
+                String.format(Email.MESSAGE_CONSTRAINTS, DeleteCommand.MESSAGE_USAGE));
     }
 
     @Test
     public void parse_invalidArg_throwsParseException() {
         assertParseFailure(parser, "testing123",
-                String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
+                String.format(MESSAGE_EMPTY_EMAIL_AND_PHONE, DeleteCommand.MESSAGE_USAGE));
     }
 
     @Test
     public void parse_bothArgs_throwsParseException() {
         assertParseFailure(parser, " p/12345678 e/test@test.com",
-                String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
+                String.format(MESSAGE_BOTH_EMAIL_AND_PHONE, DeleteCommand.MESSAGE_USAGE));
     }
 
     @Test
     public void parse_multiplePhoneArgs_throwsParseException() {
         assertParseFailure(parser, " p/12345678 p/87654321",
-                String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
+                String.format(MESSAGE_NO_UNIQUE_PREFIX_IDENTIFIER, DeleteCommand.MESSAGE_USAGE));
     }
 
     @Test
     public void parse_multipleEmailArgs_throwsParseException() {
         assertParseFailure(parser, " e/test@test.com e/test123@test.com",
+                String.format(MESSAGE_NO_UNIQUE_PREFIX_IDENTIFIER, DeleteCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_preambleAndPhone_throwsParseException() {
+        assertParseFailure(parser, " test p/12345678",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_preambleAndEmail_throwsParseException() {
+        assertParseFailure(parser, " test e/test@test.com",
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
     }
 }


### PR DESCRIPTION
Abstract the initial invalid format command for DeleteCommandParser for the following:
* Empty Phone and Email --> No EMAIL or PHONE identifier found in command!...
* Multiple Phone or Email Prefix --> Please use ONLY ONE phone or email as identifier...
* Both Phone and Email --> Please use only EMAIL or PHONE as identifier, NOT BOTH!...
* Have preamble --> Invalid command format!...

Note: If the user uses commands such as "delete p/" or "delete e/", the console will prompt the Phone.MESSAGE_CONSTRAINT or the Email.MESSAGE_CONSTRAINT.

I have also formatted the DeleteCommand description under Developer's Guide to follow the same format that most of the team members used for standardization 😄 